### PR TITLE
Enforce

### DIFF
--- a/cook_scheduler.py
+++ b/cook_scheduler.py
@@ -91,7 +91,7 @@ def create_problem(dates, community, preferences, weight_power=1.):
 
     slots = len(dates) + len(community)
     if len(names) < slots:
-	logging.warning('There %s slots but only %s cooks' % (slots, len(names)))
+	logging.warning('There are %s slots but only %s cooks' % (slots, len(names)))
 
     prob = LpProblem("Cook Cycle",LpMinimize)
 


### PR DESCRIPTION
When a cook supplies insufficient or invalid dates, the missing dates will be treated as wildcard preferences. For example if a cook enters 4 valid dates while the scheduler expects 5, then their 5th choice is *any* date. A pretty harsh way to enforce valid preference choices.